### PR TITLE
Ug feature cron support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "multiparty": "^4.2.3",
         "mustache": "^4.2.0",
         "negotiator": "^0.6.3",
-        "node-cron": "^3.0.3",
         "uniqid": "^5.4.0"
       },
       "devDependencies": {
@@ -2383,17 +2382,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/node-cron": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
-      "dependencies": {
-        "uuid": "8.3.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -3137,14 +3125,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validator": {
@@ -5162,14 +5142,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node-cron": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
-      "requires": {
-        "uuid": "8.3.2"
-      }
-    },
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -5664,11 +5636,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validator": {
       "version": "13.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fortjs",
-  "version": "2.5.1",
+  "version": "2.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fortjs",
-      "version": "2.5.1",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "class-validator": "^0.14.0",
@@ -17,6 +17,7 @@
         "multiparty": "^4.2.3",
         "mustache": "^4.2.0",
         "negotiator": "^0.6.3",
+        "node-cron": "^3.0.3",
         "uniqid": "^5.4.0"
       },
       "devDependencies": {
@@ -28,8 +29,10 @@
         "@types/multiparty": "0.0.31",
         "@types/negotiator": "^0.6.1",
         "@types/node": "^10.12.0",
+        "@types/node-cron": "^3.0.11",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "@typescript-eslint/parser": "^5.54.1",
+        "cron": "^3.1.6",
         "cross-env": "^6.0.3",
         "eslint": "^8.35.0",
         "eslint-plugin-security": "^1.7.1",
@@ -321,6 +324,12 @@
       "integrity": "sha512-EPzfFIX3K3KkZkOODu16WMVULjroa5b2hwjiMIufs9rS1rG1wkCjeE1e/7toG1QuBpyYqCUO70e1Fe6OKBsYMQ==",
       "dev": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.5.tgz",
+      "integrity": "sha512-1cyf6Ge/94zlaWIZA2ei1pE6SZ8xpad2hXaYa5JEFiaUH0YS494CZwyi4MXNpXD9oEuv6ZH0Bmh0e7F9sPhmZA==",
+      "dev": true
+    },
     "node_modules/@types/multiparty": {
       "version": "0.0.31",
       "resolved": "http://registry.npmjs.org/@types/multiparty/-/multiparty-0.0.31.tgz",
@@ -340,6 +349,12 @@
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
       "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+      "dev": true
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1120,6 +1135,16 @@
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cron": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.6.tgz",
+      "integrity": "sha512-cvFiQCeVzsA+QPM6fhjBtlKGij7tLLISnTSvFxVdnFGLdz+ZdXN37kNe0i2gefmdD17XuZA6n2uPVwzl4FxW/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
       }
     },
     "node_modules/cross-env": {
@@ -2235,6 +2260,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2348,6 +2382,17 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
@@ -3094,6 +3139,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/validator": {
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
@@ -3577,6 +3630,12 @@
       "integrity": "sha512-EPzfFIX3K3KkZkOODu16WMVULjroa5b2hwjiMIufs9rS1rG1wkCjeE1e/7toG1QuBpyYqCUO70e1Fe6OKBsYMQ==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.5.tgz",
+      "integrity": "sha512-1cyf6Ge/94zlaWIZA2ei1pE6SZ8xpad2hXaYa5JEFiaUH0YS494CZwyi4MXNpXD9oEuv6ZH0Bmh0e7F9sPhmZA==",
+      "dev": true
+    },
     "@types/multiparty": {
       "version": "0.0.31",
       "resolved": "http://registry.npmjs.org/@types/multiparty/-/multiparty-0.0.31.tgz",
@@ -3596,6 +3655,12 @@
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
       "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+      "dev": true
+    },
+    "@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
       "dev": true
     },
     "@types/semver": {
@@ -4152,6 +4217,16 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cron": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.6.tgz",
+      "integrity": "sha512-cvFiQCeVzsA+QPM6fhjBtlKGij7tLLISnTSvFxVdnFGLdz+ZdXN37kNe0i2gefmdD17XuZA6n2uPVwzl4FxW/w==",
+      "dev": true,
+      "requires": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
+      }
     },
     "cross-env": {
       "version": "6.0.3",
@@ -5000,6 +5075,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5080,6 +5161,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "requires": {
+        "uuid": "8.3.2"
+      }
     },
     "node-releases": {
       "version": "2.0.13",
@@ -5575,6 +5664,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validator": {
       "version": "13.11.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "@types/multiparty": "0.0.31",
     "@types/negotiator": "^0.6.1",
     "@types/node": "^10.12.0",
+    "@types/node-cron": "^3.0.11",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
+    "cron": "^3.1.6",
     "cross-env": "^6.0.3",
     "eslint": "^8.35.0",
     "eslint-plugin-security": "^1.7.1",
@@ -61,6 +63,7 @@
     "multiparty": "^4.2.3",
     "mustache": "^4.2.0",
     "negotiator": "^0.6.3",
+    "node-cron": "^3.0.3",
     "uniqid": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "multiparty": "^4.2.3",
     "mustache": "^4.2.0",
     "negotiator": "^0.6.3",
-    "node-cron": "^3.0.3",
     "uniqid": "^5.4.0"
   }
 }

--- a/src/abstracts/cron_task.ts
+++ b/src/abstracts/cron_task.ts
@@ -32,6 +32,7 @@ export abstract class ScheduleTask {
         return this.haltTask();
     }
 
+    // eslint-disable-next-line
     onComplete() {
 
     }

--- a/src/abstracts/cron_task.ts
+++ b/src/abstracts/cron_task.ts
@@ -1,0 +1,30 @@
+import { FORT_GLOBAL } from "../constants";
+import { ITaskScheduler } from "../interfaces";
+
+export abstract class CronTask {
+    protected scheduler: ITaskScheduler;
+    name: string;
+    expression: string;
+
+    constructor(name: string, expression: string) {
+        this.name = name || this.constructor.name;
+        this.expression = expression;
+        this.scheduler = new FORT_GLOBAL.cronJobScheduler(
+            this
+        );
+    }
+
+    abstract task(): Promise<any>;
+
+    start() {
+        return this.scheduler.start();
+    }
+
+    stop() {
+        return this.scheduler.stop();
+    }
+
+    onComplete() {
+
+    }
+}

--- a/src/abstracts/cron_task.ts
+++ b/src/abstracts/cron_task.ts
@@ -1,27 +1,35 @@
 import { FORT_GLOBAL } from "../constants";
 import { ITaskScheduler } from "../interfaces";
 
-export abstract class CronTask {
-    protected scheduler: ITaskScheduler;
+export abstract class ScheduleTask {
+    private taskScheduler_: ITaskScheduler;
     name: string;
     expression: string;
 
     constructor(name: string, expression: string) {
         this.name = name || this.constructor.name;
         this.expression = expression;
-        this.scheduler = new FORT_GLOBAL.cronJobScheduler(
+        this.taskScheduler_ = new FORT_GLOBAL.cronJobScheduler(
             this
         );
     }
 
     abstract task(): Promise<any>;
 
+    protected scheduleTask() {
+        return this.taskScheduler_.start();
+    }
+
+    protected haltTask() {
+        return this.taskScheduler_.stop();
+    }
+
     start() {
-        return this.scheduler.start();
+        this.scheduleTask();
     }
 
     stop() {
-        return this.scheduler.stop();
+        return this.haltTask();
     }
 
     onComplete() {

--- a/src/abstracts/cron_task.ts
+++ b/src/abstracts/cron_task.ts
@@ -14,7 +14,7 @@ export abstract class ScheduleTask {
         );
     }
 
-    abstract task(): Promise<any>;
+    abstract execute(): Promise<any>;
 
     protected scheduleTask() {
         return this.taskScheduler_.start();

--- a/src/abstracts/index.ts
+++ b/src/abstracts/index.ts
@@ -6,3 +6,4 @@ export * from './wall';
 export * from "./xml_parser";
 export * from './result_mapper';
 export * from "./component_option";
+export * from "./cron_task";

--- a/src/constants/fort_global.ts
+++ b/src/constants/fort_global.ts
@@ -4,7 +4,7 @@ import { TErrorHandler, TGuard, TSessionStore, TShield, TTaskScheduler, TWall, T
 import { MustacheViewEngine, DtoValidator } from "../extra";
 import { APP_NAME, CURRENT_PATH } from "./index";
 import { ETAG_TYPE } from "../enums";
-import { ISchedule, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
+import { IScheduleTaskInput, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
 import { CookieEvaluatorWall, MemorySessionStore, BlankXmlParser, PostDataEvaluatorGuard } from "../providers";
 import { RouteHandler } from "../handlers";
 import { scheduler } from "../utils";
@@ -48,7 +48,7 @@ export class FortGlobal {
     logger: Logger;
 
     validator: IDtoValidator;
-    crons: ISchedule[] = [];
+    crons: IScheduleTaskInput[] = [];
 
     get isDevelopment() {
         return isDevelopment;

--- a/src/constants/fort_global.ts
+++ b/src/constants/fort_global.ts
@@ -4,10 +4,10 @@ import { TErrorHandler, TGuard, TSessionStore, TShield, TTaskScheduler, TWall, T
 import { MustacheViewEngine, DtoValidator } from "../extra";
 import { APP_NAME, CURRENT_PATH } from "./index";
 import { ETAG_TYPE } from "../enums";
-import { ICron, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
+import { ISchedule, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
 import { CookieEvaluatorWall, MemorySessionStore, BlankXmlParser, PostDataEvaluatorGuard } from "../providers";
 import { RouteHandler } from "../handlers";
-import { CronJobManager } from "../utils";
+import { scheduler } from "../utils";
 import { DefaultCronJobScheduler } from "../providers/cron_job_scheduler";
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -24,7 +24,7 @@ export class FortGlobal {
     walls: TWall[] = [];
     errorHandler: TErrorHandler;
     cronJobScheduler: TTaskScheduler = DefaultCronJobScheduler;
-    cronJobManager = new CronJobManager();
+    cronJobManager = new scheduler();
     keepAliveTimeout = 30000;
     private shields: TShield[] = [];
     private guards: TGuard[] = [];
@@ -48,7 +48,7 @@ export class FortGlobal {
     logger: Logger;
 
     validator: IDtoValidator;
-    crons: ICron[];
+    crons: ISchedule[] = [];
 
     get isDevelopment() {
         return isDevelopment;

--- a/src/constants/fort_global.ts
+++ b/src/constants/fort_global.ts
@@ -1,12 +1,14 @@
 import { ErrorHandler, Logger } from "../models";
 import { ViewEngine, ComponentOption } from "../abstracts";
-import { TErrorHandler, TGuard, TSessionStore, TShield, TWall, TXmlParser } from "../types";
+import { TErrorHandler, TGuard, TSessionStore, TShield, TTaskScheduler, TWall, TXmlParser } from "../types";
 import { MustacheViewEngine, DtoValidator } from "../extra";
 import { APP_NAME, CURRENT_PATH } from "./index";
 import { ETAG_TYPE } from "../enums";
 import { IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
 import { CookieEvaluatorWall, MemorySessionStore, BlankXmlParser, PostDataEvaluatorGuard } from "../providers";
 import { RouteHandler } from "../handlers";
+import { CronJobManager } from "../utils";
+import { DefaultCronJobScheduler } from "../providers/cron_job_scheduler";
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 const isProduction = process.env.NODE_ENV === "production";
@@ -21,6 +23,8 @@ export class FortGlobal {
     viewEngine: ViewEngine;
     walls: TWall[] = [];
     errorHandler: TErrorHandler;
+    cronJobScheduler: TTaskScheduler = DefaultCronJobScheduler;
+    cronJobManager = new CronJobManager();
     keepAliveTimeout = 30000;
     private shields: TShield[] = [];
     private guards: TGuard[] = [];

--- a/src/constants/fort_global.ts
+++ b/src/constants/fort_global.ts
@@ -7,7 +7,6 @@ import { ETAG_TYPE } from "../enums";
 import { IScheduleTaskInput, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
 import { CookieEvaluatorWall, MemorySessionStore, BlankXmlParser, PostDataEvaluatorGuard } from "../providers";
 import { RouteHandler } from "../handlers";
-import { scheduler } from "../utils";
 import { DefaultCronJobScheduler } from "../providers/cron_job_scheduler";
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -24,7 +23,6 @@ export class FortGlobal {
     walls: TWall[] = [];
     errorHandler: TErrorHandler;
     cronJobScheduler: TTaskScheduler = DefaultCronJobScheduler;
-    cronJobManager = new scheduler();
     keepAliveTimeout = 30000;
     private shields: TShield[] = [];
     private guards: TGuard[] = [];

--- a/src/constants/fort_global.ts
+++ b/src/constants/fort_global.ts
@@ -4,7 +4,7 @@ import { TErrorHandler, TGuard, TSessionStore, TShield, TTaskScheduler, TWall, T
 import { MustacheViewEngine, DtoValidator } from "../extra";
 import { APP_NAME, CURRENT_PATH } from "./index";
 import { ETAG_TYPE } from "../enums";
-import { IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
+import { ICron, IDtoValidator, IEtagOption, IFolderMap } from "../interfaces";
 import { CookieEvaluatorWall, MemorySessionStore, BlankXmlParser, PostDataEvaluatorGuard } from "../providers";
 import { RouteHandler } from "../handlers";
 import { CronJobManager } from "../utils";
@@ -48,6 +48,7 @@ export class FortGlobal {
     logger: Logger;
 
     validator: IDtoValidator;
+    crons: ICron[];
 
     get isDevelopment() {
         return isDevelopment;

--- a/src/interfaces/cron_manager.ts
+++ b/src/interfaces/cron_manager.ts
@@ -1,0 +1,39 @@
+import { FORT_GLOBAL } from "../constants";
+
+export interface ITaskScheduler {
+    start();
+    stop();
+}
+
+export abstract class CronTask {
+    protected scheduler: ITaskScheduler;
+    name: string;
+    expression: string;
+
+    constructor(expression: string) {
+        this.name = this.constructor.name;
+        this.expression = expression;
+        this.scheduler = new FORT_GLOBAL.cronJobScheduler(
+            this
+        );
+    }
+
+    abstract task();
+
+    start() {
+        return this.scheduler.start();
+    }
+
+    stop() {
+        return this.scheduler.stop();
+    }
+}
+
+class DailyBalanceCronTask extends CronTask {
+
+    task() {
+        // run some tasks
+    }
+}
+
+const taskInstance = new DailyBalanceCronTask("");

--- a/src/interfaces/cron_manager.ts
+++ b/src/interfaces/cron_manager.ts
@@ -1,43 +1,12 @@
-import { FORT_GLOBAL } from "../constants";
+import { TCronTask } from "../types";
 
 export interface ITaskScheduler {
     start();
     stop();
 }
 
-export abstract class CronTask {
-    protected scheduler: ITaskScheduler;
-    name: string;
+export interface ICron {
+    name?: string;
     expression: string;
-
-    constructor(expression: string) {
-        this.name = this.constructor.name;
-        this.expression = expression;
-        this.scheduler = new FORT_GLOBAL.cronJobScheduler(
-            this
-        );
-    }
-
-    abstract task();
-
-    start() {
-        return this.scheduler.start();
-    }
-
-    stop() {
-        return this.scheduler.stop();
-    }
-
-    onComplete() {
-        
-    }
+    task: TCronTask
 }
-
-class DailyBalanceCronTask extends CronTask {
-
-    task() {
-        // run some tasks
-    }
-}
-
-const taskInstance = new DailyBalanceCronTask("");

--- a/src/interfaces/cron_manager.ts
+++ b/src/interfaces/cron_manager.ts
@@ -1,12 +1,12 @@
-import { TCronTask } from "../types";
+import { TScheduleTask } from "../types";
 
 export interface ITaskScheduler {
     start();
     stop();
 }
 
-export interface ICron {
+export interface ISchedule {
     name?: string;
     expression: string;
-    task: TCronTask
+    task: TScheduleTask
 }

--- a/src/interfaces/cron_manager.ts
+++ b/src/interfaces/cron_manager.ts
@@ -27,6 +27,10 @@ export abstract class CronTask {
     stop() {
         return this.scheduler.stop();
     }
+
+    onComplete() {
+        
+    }
 }
 
 class DailyBalanceCronTask extends CronTask {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -19,5 +19,6 @@ export * from "./parent_route";
 export * from "./route_match";
 export * from "./session_value";
 export * from "./view_read_option";
+export * from "./cron_manager";
 
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -19,6 +19,6 @@ export * from "./parent_route";
 export * from "./route_match";
 export * from "./session_value";
 export * from "./view_read_option";
-export * from "./cron_manager";
+export * from "./task_scheduler";
 
 

--- a/src/interfaces/task_scheduler.ts
+++ b/src/interfaces/task_scheduler.ts
@@ -5,7 +5,7 @@ export interface ITaskScheduler {
     stop();
 }
 
-export interface ISchedule {
+export interface IScheduleTaskInput {
     name?: string;
     expression: string;
     task: TScheduleTask

--- a/src/models/fort.ts
+++ b/src/models/fort.ts
@@ -7,7 +7,7 @@ import { ERROR_TYPE } from "../enums";
 import { LogHelper, promise, removeLastSlash, removeFirstSlash, setResultMapper } from "../helpers";
 import { TaskSchedulerManager, isArray } from "../utils";
 import { Logger } from "./logger";
-import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, IScheduleTaskInput } from "../interfaces";
+import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute } from "../interfaces";
 
 export class Fort {
 

--- a/src/models/fort.ts
+++ b/src/models/fort.ts
@@ -7,7 +7,7 @@ import { ERROR_TYPE } from "../enums";
 import { LogHelper, promise, removeLastSlash, removeFirstSlash, setResultMapper } from "../helpers";
 import { TaskSchedulerManager, isArray } from "../utils";
 import { Logger } from "./logger";
-import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, ISchedule } from "../interfaces";
+import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, IScheduleTaskInput } from "../interfaces";
 
 export class Fort {
 

--- a/src/models/fort.ts
+++ b/src/models/fort.ts
@@ -266,6 +266,7 @@ export class Fort {
     }
 
     static destroy(): Promise<void> {
+        this.scheduler.stopAll();
         return promise((res) => {
             this.instance.httpServer.close(res);
         });

--- a/src/models/fort.ts
+++ b/src/models/fort.ts
@@ -7,7 +7,7 @@ import { ERROR_TYPE } from "../enums";
 import { LogHelper, promise, removeLastSlash, removeFirstSlash, setResultMapper } from "../helpers";
 import { isArray } from "../utils";
 import { Logger } from "./logger";
-import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute } from "../interfaces";
+import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, ICron } from "../interfaces";
 
 export class Fort {
 
@@ -275,4 +275,7 @@ export class Fort {
         FORT_GLOBAL.validator = validator;
     }
 
+    static set crons(value: ICron[]) {
+        FORT_GLOBAL.crons = value;
+    }
 }

--- a/src/models/fort.ts
+++ b/src/models/fort.ts
@@ -5,9 +5,9 @@ import { FORT_GLOBAL } from "../constants/fort_global";
 import * as http from "http";
 import { ERROR_TYPE } from "../enums";
 import { LogHelper, promise, removeLastSlash, removeFirstSlash, setResultMapper } from "../helpers";
-import { isArray } from "../utils";
+import { TaskSchedulerManager, isArray } from "../utils";
 import { Logger } from "./logger";
-import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, ICron } from "../interfaces";
+import { IDtoValidator, IEtagOption, IFolderMap, IControllerRoute, ISchedule } from "../interfaces";
 
 export class Fort {
 
@@ -275,7 +275,5 @@ export class Fort {
         FORT_GLOBAL.validator = validator;
     }
 
-    static set crons(value: ICron[]) {
-        FORT_GLOBAL.crons = value;
-    }
+    static scheduler = new TaskSchedulerManager();
 }

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -1,13 +1,14 @@
-import { CronTask, ITaskScheduler } from "../interfaces";
+import { ScheduleTask } from "../abstracts";
+import { ITaskScheduler } from "../interfaces";
 
 export class DefaultCronJobScheduler implements ITaskScheduler {
     private job_;
 
-    constructor(name: string, cronTask: CronTask) {
+    constructor(name: string, cronTask: ScheduleTask) {
         // Dynamically import the cron package
         const cron = require('cron');
         this.job_ = new cron.CronJob(cronTask.expression, async () => {
-            await cronTask.task();
+            await cronTask.execute();
             cronTask.onComplete();
         });
     }

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -1,14 +1,14 @@
 import { ScheduleTask } from "../abstracts";
 import { ITaskScheduler } from "../interfaces";
+import { CronJob } from "cron";
 
 export class DefaultCronJobScheduler implements ITaskScheduler {
-    private job_;
+    private job_: CronJob;
 
     constructor(cronTask: ScheduleTask) {
         // Dynamically import the cron package
         // eslint-disable-next-line
-        const cron = require('cron');
-        this.job_ = new cron.CronJob(cronTask.expression, async () => {
+        this.job_ = new CronJob(cronTask.expression, async () => {
             await cronTask.execute();
             cronTask.onComplete();
         });

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -1,4 +1,5 @@
 import { ScheduleTask } from "../abstracts";
+import { FORT_GLOBAL } from "../constants";
 import { ITaskScheduler } from "../interfaces";
 import { CronJob } from "cron";
 
@@ -9,7 +10,12 @@ export class DefaultCronJobScheduler implements ITaskScheduler {
         // Dynamically import the cron package
         // eslint-disable-next-line
         this.job_ = new CronJob(cronTask.expression, async () => {
-            await cronTask.execute();
+            try {
+                await cronTask.execute();
+            }
+            catch (ex) {
+                FORT_GLOBAL.logger.error(ex);
+            }
             cronTask.onComplete();
         });
     }

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -1,0 +1,19 @@
+import { CronTask, ITaskScheduler } from "../interfaces";
+
+export class DefaultCronJobScheduler implements ITaskScheduler {
+    private job_;
+
+    constructor(name: string, cronTask: CronTask) {
+        // Dynamically import the cron package
+        const cron = require('cron');
+        this.job_ = new cron.CronJob(cronTask.expression, cronTask.task);
+    }
+
+    start() {
+        return this.job_.start();
+    }
+
+    stop() {
+        return this.job_.stop();
+    }
+}

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -4,8 +4,9 @@ import { ITaskScheduler } from "../interfaces";
 export class DefaultCronJobScheduler implements ITaskScheduler {
     private job_;
 
-    constructor(name: string, cronTask: ScheduleTask) {
+    constructor(cronTask: ScheduleTask) {
         // Dynamically import the cron package
+        // eslint-disable-next-line
         const cron = require('cron');
         this.job_ = new cron.CronJob(cronTask.expression, async () => {
             await cronTask.execute();

--- a/src/providers/cron_job_scheduler.ts
+++ b/src/providers/cron_job_scheduler.ts
@@ -6,7 +6,10 @@ export class DefaultCronJobScheduler implements ITaskScheduler {
     constructor(name: string, cronTask: CronTask) {
         // Dynamically import the cron package
         const cron = require('cron');
-        this.job_ = new cron.CronJob(cronTask.expression, cronTask.task);
+        this.job_ = new cron.CronJob(cronTask.expression, async () => {
+            await cronTask.task();
+            cronTask.onComplete();
+        });
     }
 
     start() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { Controller, Guard, Shield, Wall, XmlParser } from '../abstracts';
-import { IControllerRoute, IHttpResult, ISessonStore } from '../interfaces';
+import { CronTask, IControllerRoute, IHttpResult, ISessonStore, ITaskScheduler } from '../interfaces';
 import { ErrorHandler } from '../models';
 
 export * from './http_format_result';
@@ -17,3 +17,4 @@ export type TShield = Class<Shield>;
 export type TWall = Class<Wall>;
 export type TXmlParser = Class<XmlParser, []>;
 export type TErrorHandler = Class<ErrorHandler, []>;
+export type TTaskScheduler = Class<ITaskScheduler, [CronTask]>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
-import { Controller, Guard, Shield, Wall, XmlParser } from '../abstracts';
-import { CronTask, IControllerRoute, IHttpResult, ISessonStore, ITaskScheduler } from '../interfaces';
+import { Controller, ScheduleTask, Guard, Shield, Wall, XmlParser } from '../abstracts';
+import { IControllerRoute, IHttpResult, ISessonStore, ITaskScheduler } from '../interfaces';
 import { ErrorHandler } from '../models';
 
 export * from './http_format_result';
@@ -17,5 +17,5 @@ export type TShield = Class<Shield>;
 export type TWall = Class<Wall>;
 export type TXmlParser = Class<XmlParser, []>;
 export type TErrorHandler = Class<ErrorHandler, []>;
-export type TTaskScheduler = Class<ITaskScheduler, [CronTask]>;
-export type TCronTask = Class<CronTask>;
+export type TTaskScheduler = Class<ITaskScheduler, [ScheduleTask]>;
+export type TScheduleTask = Class<ScheduleTask>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,3 +18,4 @@ export type TWall = Class<Wall>;
 export type TXmlParser = Class<XmlParser, []>;
 export type TErrorHandler = Class<ErrorHandler, []>;
 export type TTaskScheduler = Class<ITaskScheduler, [CronTask]>;
+export type TCronTask = Class<CronTask>;

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -24,4 +24,13 @@ export class TaskSchedulerManager {
     static add(...values: IScheduleTaskInput[]) {
         FORT_GLOBAL.crons = [...FORT_GLOBAL.crons, ...values];
     }
+
+    execute(name: string) {
+        const cron = FORT_GLOBAL.crons.find(q => q.name === name);
+        if (!cron) {
+            throw new Error(`Cron task ${name} does not exist`);
+        }
+
+        return new cron.task(cron.name, cron.expression).execute();
+    }
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,5 +1,5 @@
 import { FORT_GLOBAL } from "../constants";
-import { ISchedule } from "../interfaces";
+import { IScheduleTaskInput } from "../interfaces";
 
 export class TaskSchedulerManager {
     start(name: string) {
@@ -7,13 +7,21 @@ export class TaskSchedulerManager {
         if (!cron) {
             throw new Error(`Cron task ${name} does not exist`);
         }
+        this.startTask_(cron);
+    }
+
+    private startTask_(cron: IScheduleTaskInput) {
+        const task = new cron.task(cron.name, cron.expression);
+        task.start();
     }
 
     startAll() {
-
+        FORT_GLOBAL.crons.forEach(cron => {
+            this.startTask_(cron);
+        });
     }
 
-    static add(...values: ISchedule[]) {
+    static add(...values: IScheduleTaskInput[]) {
         FORT_GLOBAL.crons = [...FORT_GLOBAL.crons, ...values];
     }
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -47,7 +47,6 @@ export class TaskSchedulerManager {
 
     getTask<T = ScheduleTask>(name: string) {
         const cron = tasks.get(name);
-        console.log("tasks", tasks);
         if (!cron) {
             throw new Error(`Cron task ${name} does not exist`);
         }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,0 +1,6 @@
+
+export class CronJobManager {
+    createJob() {
+        
+    }
+}

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,15 +1,25 @@
+import { ScheduleTask } from "../abstracts";
 import { FORT_GLOBAL } from "../constants";
 import { IScheduleTaskInput } from "../interfaces";
 
+interface IScheduleTaskStarted {
+    task: ScheduleTask
+}
+
+const tasks = new Map<string, IScheduleTaskStarted>;
+
 export class TaskSchedulerManager {
     start(name: string) {
-        const cron = this.getTask(name);
+        const cron = this.getTaskInputByName(name);
         this.startTask_(cron);
     }
 
     private startTask_(cron: IScheduleTaskInput) {
         const task = new cron.task(cron.name, cron.expression);
         task.start();
+        tasks.set(cron.name, {
+            task: task
+        });
     }
 
     startAll() {
@@ -18,20 +28,45 @@ export class TaskSchedulerManager {
         });
     }
 
-    static add(...values: IScheduleTaskInput[]) {
+    add(...values: IScheduleTaskInput[]) {
         FORT_GLOBAL.crons = [...FORT_GLOBAL.crons, ...values];
     }
 
     execute(name: string) {
-        const cron = this.getTask(name);
+        const cron = this.getTaskInputByName(name);
         return new cron.task(cron.name, cron.expression).execute();
     }
 
-    getTask(name: string) {
+    getTaskInputByName(name: string) {
         const cron = FORT_GLOBAL.crons.find(q => q.name === name);
+        if (!cron) {
+            throw new Error(`Cron task ${name} is not registered.`);
+        }
+        return cron;
+    }
+
+    getTask<T = ScheduleTask>(name: string) {
+        const cron = tasks.get(name);
+        console.log("tasks", tasks);
         if (!cron) {
             throw new Error(`Cron task ${name} does not exist`);
         }
-        return cron;
+        return cron.task as T;
+    }
+
+    private stopTask_(task: ScheduleTask) {
+        task.stop();
+        tasks.delete(task.name);
+    }
+
+    stop(name: string) {
+        const cron = this.getTask(name);
+        this.stopTask_(cron);
+    }
+
+    stopAll() {
+        tasks.forEach(cron => {
+            this.stopTask_(cron.task);
+        });
     }
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,6 +1,19 @@
+import { FORT_GLOBAL } from "../constants";
+import { ISchedule } from "../interfaces";
 
-export class CronJobManager {
+export class TaskSchedulerManager {
     start(name: string) {
-        
+        const cron = FORT_GLOBAL.crons.find(q => q.name === name);
+        if (!cron) {
+            throw new Error(`Cron task ${name} does not exist`);
+        }
+    }
+
+    startAll() {
+
+    }
+
+    static add(...values: ISchedule[]) {
+        FORT_GLOBAL.crons = [...FORT_GLOBAL.crons, ...values];
     }
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -3,10 +3,7 @@ import { IScheduleTaskInput } from "../interfaces";
 
 export class TaskSchedulerManager {
     start(name: string) {
-        const cron = FORT_GLOBAL.crons.find(q => q.name === name);
-        if (!cron) {
-            throw new Error(`Cron task ${name} does not exist`);
-        }
+        const cron = this.getTask(name);
         this.startTask_(cron);
     }
 
@@ -26,11 +23,15 @@ export class TaskSchedulerManager {
     }
 
     execute(name: string) {
+        const cron = this.getTask(name);
+        return new cron.task(cron.name, cron.expression).execute();
+    }
+
+    getTask(name: string) {
         const cron = FORT_GLOBAL.crons.find(q => q.name === name);
         if (!cron) {
             throw new Error(`Cron task ${name} does not exist`);
         }
-
-        return new cron.task(cron.name, cron.expression).execute();
+        return cron;
     }
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,6 +1,4 @@
 
 export class CronJobManager {
-    createJob() {
-        
-    }
+
 }

--- a/src/utils/cron_manager.ts
+++ b/src/utils/cron_manager.ts
@@ -1,4 +1,6 @@
 
 export class CronJobManager {
-
+    start(name: string) {
+        
+    }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './is_array';
 export * from './promise_resolve';
 export * from './compare_string';
 export * from './session_manager';
+export * from './cron_manager';

--- a/tests/general/crons/counter.spec.ts
+++ b/tests/general/crons/counter.spec.ts
@@ -1,0 +1,41 @@
+import { initServer } from "..";
+import { viewResult, Fort, textResult } from "fortjs";
+
+describe("counter scheduler", () => {
+    beforeAll(async () => {
+        await initServer();
+    });
+
+    const taskName = "Counter";
+
+
+    it("get invalid class task", async () => {
+        try {
+            const task = Fort.scheduler.getTaskInputByName("taskName");
+        } catch (error) {
+            expect(error.message).toEqual("Cron task taskName is not registered.");
+        }
+    })
+
+    it("get valid class task", async () => {
+        const task = Fort.scheduler.getTaskInputByName(taskName);
+        expect(task.name).toEqual(taskName);
+    })
+
+    it("get invalid task", async () => {
+        try {
+            const task = Fort.scheduler.getTask("taskName");
+        } catch (error) {
+            expect(error.message).toEqual("Cron task taskName does not exist");
+        }
+    })
+
+    it("value check", async () => {
+        const task = Fort.scheduler.getTask(taskName);
+        expect(task['counter']).toEqual(0);
+    })
+
+    afterAll(() => {
+        return Fort.destroy();
+    });
+})

--- a/tests/general/crons/counter.spec.ts
+++ b/tests/general/crons/counter.spec.ts
@@ -1,5 +1,6 @@
 import { initServer } from "..";
 import { viewResult, Fort, textResult } from "fortjs";
+import { CounterScheduler } from "./counter";
 
 describe("counter scheduler", () => {
     beforeAll(async () => {
@@ -33,6 +34,18 @@ describe("counter scheduler", () => {
     it("value check", async () => {
         const task = Fort.scheduler.getTask(taskName);
         expect(task['counter']).toEqual(0);
+    })
+
+    it("value check after 5 second", async () => {
+        const task = Fort.scheduler.getTask<CounterScheduler>(taskName);
+        await new Promise((res) => {
+            setTimeout(res, 2000);
+        })
+        expect(task.counter).toEqual(2);
+        await new Promise((res) => {
+            setTimeout(res, 2000);
+        })
+        expect(task.counter).toEqual(4);
     })
 
     afterAll(() => {

--- a/tests/general/crons/counter.spec.ts
+++ b/tests/general/crons/counter.spec.ts
@@ -1,7 +1,10 @@
 import { initServer } from "..";
 import { viewResult, Fort, textResult } from "fortjs";
 import { CounterScheduler } from "./counter";
+// import { } from "jest;
 
+// jest.
+// jest.sp
 describe("counter scheduler", () => {
     beforeAll(async () => {
         await initServer();
@@ -46,6 +49,17 @@ describe("counter scheduler", () => {
             setTimeout(res, 2000);
         })
         expect(task.counter).toEqual(4);
+    })
+
+    it("check for error", async () => {
+        const logSpy = jest.spyOn(Fort.logger, "error");
+        const task = Fort.scheduler.getTask<CounterScheduler>(taskName);
+        await new Promise((res) => {
+            setTimeout(res, 2000);
+        })
+        expect(task.counter).toEqual(6);
+        expect(logSpy).toHaveBeenCalledWith('Error thrown on 5');
+        logSpy.mockRestore();
     })
 
     afterAll(() => {

--- a/tests/general/crons/counter.ts
+++ b/tests/general/crons/counter.ts
@@ -5,5 +5,8 @@ export class CounterScheduler extends ScheduleTask {
 
     async execute(): Promise<any> {
         this.counter++;
+        if (this.counter == 5) {
+            throw "Error thrown on 5";
+        }
     }
 }

--- a/tests/general/crons/counter.ts
+++ b/tests/general/crons/counter.ts
@@ -1,0 +1,9 @@
+import { ScheduleTask } from "fortjs";
+
+export class CounterScheduler extends ScheduleTask {
+    counter = 0;
+
+    async execute(): Promise<any> {
+        this.counter++;
+    }
+}

--- a/tests/general/index.ts
+++ b/tests/general/index.ts
@@ -8,6 +8,7 @@ import { MyComponentOption } from "./extra/my_component_option";
 import { WallWithoutOutgoing } from "./walls/wall_without_outgoing";
 import { Wall1 } from "./walls/wall1";
 import { RequestLogger } from "./walls/request_logger";
+import { CounterScheduler } from "./crons/counter";
 
 const contentsPath = Path.join(__dirname, "../contents");
 // const staticFolderPath = Path.join(__dirname, "../static");
@@ -31,6 +32,12 @@ export const initServer = async () => {
         alias: "/",
         path: contentsPath
     }];
+    Fort.scheduler.add({
+        expression: "*/1 * * * *",
+        task: CounterScheduler,
+        name: "Counter"
+    });
+    Fort.scheduler.startAll();
     await Fort.create();
 };
 

--- a/tests/general/index.ts
+++ b/tests/general/index.ts
@@ -33,7 +33,7 @@ export const initServer = async () => {
         path: contentsPath
     }];
     Fort.scheduler.add({
-        expression: "*/1 * * * *",
+        expression: "*/1 * * * * *",
         task: CounterScheduler,
         name: "Counter"
     });


### PR DESCRIPTION
Add support for cron/scheduler

1. Using #cron package for default scheduler. 
2. Have defined TaskScheduler which abstracts the scheduling of tasks and thus can be customized with any package or custom code.
3. Every cron task is a class which extends ScheduleTask and have execute method to run the tasks.
4. The cron expression and other inputs can be passed in crons list
5. One cron job can be used with multiple expression with different name.