### PR TITLE
add feature middleware execute api

### DIFF
--- a/src/abstracts/component.ts
+++ b/src/abstracts/component.ts
@@ -37,4 +37,20 @@ export class Component {
 
     private componentProp_: IComponentProp;
 
+    middleware(middleware) {
+        return {
+            execute: () => {
+                return new Promise<void>((res, rej) => {
+                    middleware(this.request, this.response, (err) => {
+                        if (err) {
+                            rej(err)
+                        }
+                        else {
+                            res();
+                        }
+                    });
+                });
+            }
+        }
+    }
 }

--- a/tests/general/extra/middleware.spec.ts
+++ b/tests/general/extra/middleware.spec.ts
@@ -1,0 +1,41 @@
+import { initServer } from "..";
+import { CookieController } from "../controllers/cookie_controller";
+import { viewResult, Fort, IHttpResponse } from "fortjs";
+
+describe('DefaultController', () => {
+    let controller = new CookieController();
+
+    beforeAll(async () => {
+        await initServer();
+        controller.initialize();
+    });
+
+    it('execute middleware successfull', async () => {
+        let middlewareExecuted = false;
+        const middleware = (req, res: IHttpResponse, next) => {
+            middlewareExecuted = true;
+            next();
+        };
+
+        await controller.middleware(middleware).execute();
+        expect(middlewareExecuted).toEqual(true);
+    });
+
+    it('execute middleware with reject', async () => {
+        let middlewareExecuted = false;
+        const middleware = (req, res: IHttpResponse, next) => {
+            middlewareExecuted = true;
+            next("Rejected");
+        };
+        try {
+            await controller.middleware(middleware).execute();
+        } catch (error) {
+            expect(error).toEqual("Rejected");
+        }
+        expect(middlewareExecuted).toEqual(true);
+    });
+
+    afterAll(() => {
+        return Fort.destroy();
+    });
+});


### PR DESCRIPTION
# Add feature middleware execute api 

```
const middleware = (req, res: IHttpResponse, next) => {
            middlewareExecuted = true;
            next();
};

await controller.middleware(middleware).execute();
```

